### PR TITLE
Build on Java 11 and 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ],
+  [ platform: 'linux', jdk: '17' ],
+])


### PR DESCRIPTION
This is a followup to #22.

Now that the repository is on the latest tooling versions that support Java 8, those same versions also support 11 and 17.

Newer tooling and Jenkins versions only support Java 11+. If this is merged I can follow up with one more PR to upgrade the repo to the current tooling and recommended Jenkins baseline.